### PR TITLE
APIContract/comment-delete

### DIFF
--- a/api-contract/contract.yaml
+++ b/api-contract/contract.yaml
@@ -736,20 +736,31 @@ components:
           type: string
         updatedAt:
           type: string
-        imageProfile:
-          type: string
-          format: binary
         postId:
           type: string
     Comment:
       type: object
       properties:
+        username:
+          type: string
         comment:
           type: string
-          items:
-            $ref: '#/components/schemas/Post'
+        canLike:
+          type: boolean
+        canUnlike: 
+          type: boolean
+        likeCount:
+          type: integer
+        tags: 
+          type: string
+        createdAt:
+          type: string
+        updatedAt:
+          type: string
         commentId:
-          type: string   
+          type: string
+        postId:
+          type: string
     Friend:
       type: object
       properties:
@@ -797,7 +808,7 @@ components:
         user:
           type: string
           items:
-            $ref: '#/components/schemas/UserProfile'      
+          $ref: '#/components/schemas/UserProfile'      
         post:
           type: array
           items:

--- a/api-contract/contract.yaml
+++ b/api-contract/contract.yaml
@@ -287,6 +287,15 @@ paths:
       summary: View a list of posts
       description: This can be done by anyone.
       operationId: viewPostList
+      requestBody:
+        description: View post object
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Post'
+        required: true
       responses:
         default:
           description: successful operation
@@ -303,7 +312,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Post'
+              $ref: '#/components/schemas/Comment'
         required: true
       responses:
         default:
@@ -320,7 +329,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Post'
+              $ref: '#/components/schemas/Comment'
         required: true
       security:
         - bearer_auth: []
@@ -339,7 +348,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Post'
+              $ref: '#/components/schemas/Comment'
         required: true
       security:
         - bearer_auth: []
@@ -347,19 +356,21 @@ paths:
         default:
           description: successful operation
           content: {}
+  /post/comment/{commentId}:
     delete:
       tags:
       - post
       summary: Delete comment
       description: This can be done by the logged in user.
       operationId: deleteComment
-      requestBody:
-        description: Delete post object
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Post'
+      parameters:
+      - name: commentId
+        in: path
+        description: |
+          The commentId to be deleted
         required: true
+        schema:
+          type: string
       security:
         - bearer_auth: []
       responses:
@@ -386,25 +397,6 @@ paths:
         default:
           description: successful operation
           content: {}
-    delete:
-      tags:
-      - friend
-      summary: Delete a friend
-      description: This can be done by the logged in user.
-      operationId: deleteFriend
-      requestBody:
-        description: Delete friend object
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Friend'
-        required: true
-      security:
-        - bearer_auth: []
-      responses:
-        default:
-          description: successful operation
-          content: {}
     put:
       tags:
       - friend
@@ -418,6 +410,27 @@ paths:
             schema:
               $ref: '#/components/schemas/Friend'
         required: true
+      security:
+        - bearer_auth: []
+      responses:
+        default:
+          description: successful operation
+          content: {}
+  /friend/{friendId}:
+    delete:
+      tags:
+      - friend
+      summary: Delete a friend
+      description: This can be done by the logged in user.
+      operationId: deleteFriend
+      parameters:
+      - name: friendId
+        in: path
+        description: |
+          The friendId to be deleted
+        required: true
+        schema:
+          type: string
       security:
         - bearer_auth: []
       responses:
@@ -485,19 +498,21 @@ paths:
         default:
           description: successful operation
           content: {}
+  /group/{groupId}:
     delete:
       tags:
       - group
       summary: Delete a group of friends
       description: This can be done by the logged in user.
       operationId: deleteGroup
-      requestBody:
-        description: Delete group object
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Group'
+      parameters:
+      - name: groupId
+        in: path
+        description: |
+          The groupId to be deleted
         required: true
+        schema:
+          type: string
       security:
         - bearer_auth: []
       responses:
@@ -725,6 +740,15 @@ components:
           type: string
           format: binary
         postId:
+          type: string
+    Comment:
+      type: object
+      properties:
+        comment:
+          type: string
+          items:
+            $ref: '#/components/schemas/Post'
+        commentId:
           type: string   
     Friend:
       type: object


### PR DESCRIPTION
New schema: 'Comment' and modified delete operations.

Schema:
![Comment schema](https://user-images.githubusercontent.com/92758849/163894920-ccbe974a-b92e-40ea-8ff3-a5934376ebc3.png)
How it looks:
![schema](https://user-images.githubusercontent.com/92758849/163895000-80ac786c-9064-4cd7-9ad0-72ba77284c32.png)

Delete operations:
![comment](https://user-images.githubusercontent.com/92758849/163895034-f7b999e8-d89b-4213-a952-f00e3acaadc2.png)
![friend](https://user-images.githubusercontent.com/92758849/163895047-ea2ea8ee-dcb2-44c9-af28-cf350910b935.png)
![group](https://user-images.githubusercontent.com/92758849/163895050-85bc5e08-8b57-485e-a71b-f4f1c81ca65b.png)

